### PR TITLE
Update `pyproject.toml` for backward compatibility

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1042,4 +1042,4 @@ h11 = ">=0.9.0,<1"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "ed13e2079cfff0d8c181e7473795ee5d111eab65d67083186ef036ca4225b1ed"
+content-hash = "b3d073149cfb5b3dc4e3487c257e61e17100fb1922f9d246a9ab25a3a83f2e8f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pytest_qaseio = "pytest_qaseio.plugin"
 python = "^3.11"
 qaseio = "^4.0.0"
 selenium = "^4.21.0"
-arrow = "^1.3.0"
+arrow = "^1.2.3"
 filelock = "^3.14.0"
 pytest = ">=7.2.2,<9.0.0"
 


### PR DESCRIPTION
Hi guys! 
I have some problem using `pytest-qaseio` with `gitlint`.
Currently in our project we want to use [gitlint](https://github.com/jorisroovers/gitlint/tree/main), but it conflicts with dependecies of `pytest-qaseio`.
And it seems that gitlint repo is no longer active (no updates in the last year) and yours is not, so could you please extend verison of [arrow](https://pypi.org/project/arrow/) for backward compatability.

Example of version conflicts:
![image](https://github.com/user-attachments/assets/afbdafd5-63f6-42f9-97f3-13f007c346ba)