### PR TITLE
Fix skipping reports for already passed tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 We follow [Semantic Versions](https://semver.org/).
 
+# Version 2.2.1
+- Fix skipping reports for already passed tests
+
 # Version 2.2.0
 - Replace `qaseio` to `qase-api-client` because first one was [deprecated](https://github.com/qase-tms/qase-python#deprecated)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pytest-qaseio"
 description = "Pytest plugin for Qase.io integration"
-version = "2.2.0"
+version = "2.2.1"
 license = "MIT"
 
 authors = [

--- a/pytest_qaseio/plugin.py
+++ b/pytest_qaseio/plugin.py
@@ -197,14 +197,19 @@ class QasePlugin:
         if not should_report:
             return
         case_id = self._tests[item.nodeid]
+
+        # We can't use `item.nodeid` completely because it may contain unique
+        # ids of parameterized tests. So we split it by `[` - start of id.
+        test_path = item.nodeid.split("[")[0]
+
         # No need to report same passed status,
         # while skipped and failed should be always reported
-        if not case_id or (item.nodeid in self._qase_results and report.passed):
+        if not case_id or (test_path in self._qase_results and report.passed):
             return
         if not self._current_run:
             raise plugin_exceptions.RunNotConfigured()
         try:
-            self._qase_results[item.nodeid] = self._client.report_test_results(
+            self._qase_results[test_path] = self._client.report_test_results(
                 run=self._current_run,
                 report_data=self._converter.prepare_report_data(
                     run_id=cast(int, self._current_run.id),


### PR DESCRIPTION
We had an issue that the parameterized test for one case was overwriting failed results with passed results, and we weren't seeing problems in time.

This fix ensures that passed results are not duplicated and all failed and missed results are saved.