### PR TITLE
Update xfailed tests handling

### DIFF
--- a/.vscode/project-related-words.txt
+++ b/.vscode/project-related-words.txt
@@ -29,3 +29,4 @@ makereport
 firstresult
 ipdb
 geckodriver
+xfailed

--- a/README.md
+++ b/README.md
@@ -56,17 +56,17 @@ def test_demo():
 
 Since this package is mostly used for selenium tests, it expects to get browser
 name to use in Qase.io test run name and in attachments path. By default you can
- provide it using `--webdriver` flag. But you can also override
- `pytest_qase_browser_name` hook to implement some custom logic.
- Here's default implementation of hook:
+provide it using `--webdriver` flag. But you can also override
+`pytest_qase_browser_name` hook to implement some custom logic.
+Here's an example of custom hook:
 
- ```python
-@pytest.hookimpl(trylast=True)
+```python
+@pytest.hookimpl(tryfirst=True)
 def pytest_qase_browser_name(config: pytest.Config) -> str:
     """Try to get browser name from `webdriver` pytest option."""
     return config.getoption("--webdriver")
 
- ```
+```
 
 To enable plugin use flag `--qase-enabled`.
 


### PR DESCRIPTION
* We decided to use `blocked` status so as not to mislead the QA team. If they see a `failed` case, they will go to retest it. But `xfail` implies that the case fails for some already known reason. So the `blocked` status will let them know that the case is blocked for some reason described in the `xfail` comment (this comment will be duplicated as a result of the case run).
* Also was updated doc about overriding `pytest_qase_browser_name`