### PR TITLE
Add hook to override `DebugInfo`

### DIFF
--- a/.vscode/project-related-words.txt
+++ b/.vscode/project-related-words.txt
@@ -2,6 +2,7 @@ addhooks
 addinivalue
 addoption
 filelock
+funcargs
 hookspecs
 hookwrapper
 modifyitems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 We follow [Semantic Versions](https://semver.org/).
 
+## Version 2.5.0 (15.07.25)
+
+- Add pytest hook `pytest_get_debug_info` to override `DebugInfo`
+
+  This allows customizing `DebugInfo` for failed tests in various testing
+  frameworks. Previously it was based on selenium webdriver which is not
+  compatible with other frameworks (e.g. `Playwright`)
+
+  By default, `pytest_get_debug_info` will return `SeleniumDebugInfo`, as before.
+
 ## Version 2.4.0
 
 - Update ``xfailed`` tests handling:

--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ def pytest_qase_browser_name(config: pytest.Config) -> str:
 
 ```
 
+Also, by default, debug message for failed tests is generated based on selenium
+webdriver. So if you are using another framework, you need to prepare your own
+debug info class that conforms to the [DebugInfo](pytest_qaseio/debug_info.py#L14-L21)
+protocol and override `pytest_get_debug_info` hook.
+
+Playwright example:
+
+```python
+@pytest.hookimpl(tryfirst=True)
+def pytest_get_debug_info(item: pytest.Function) -> DebugInfo:
+    """Return object with test debug information based on Playwright objects."""
+    return PlaywrightDebugInfo(item)
+
+...
+class PlaywrightDebugInfo:
+    """Representation of playwright debug information."""
+
+    def __init__(self, item: pytest.Function):
+        self.page = item.funcargs['page']
+        self.url = self.page.url
+        self.test_name = item.name
+
+    def generate_debug_comment(self, file_storage: FileStorage, folder: str) -> str:
+      return f"""
+          * TEST NAME: {self.test_name}
+          * URL: [URL]({self.url})
+      """
+
+```
+
 To enable plugin use flag `--qase-enabled`.
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pytest-qaseio"
 description = "Pytest plugin for Qase.io integration"
-version = "2.4.0"
+version = "2.5.0"
 license = "MIT"
 
 authors = [

--- a/pytest_qaseio/converter.py
+++ b/pytest_qaseio/converter.py
@@ -7,7 +7,7 @@ import pytest
 from qase.api_client_v1.models.result_create import ResultCreate
 from qase.api_client_v1.models.run_create import RunCreate
 
-from . import constants, debug_info, plugin_exceptions, storage
+from . import constants, plugin_exceptions, storage
 
 
 class QaseConverter:
@@ -19,6 +19,7 @@ class QaseConverter:
         env: str,
         project_code: str,
         file_storage: storage.FileStorage | None,
+        config: pytest.Config,
     ):
         """Init converter."""
         super().__init__()
@@ -30,6 +31,7 @@ class QaseConverter:
         self._browser = browser
         self._project_code = project_code
         self._file_storage = file_storage
+        self._config = config
 
     def prepare_run_data(
         self,
@@ -144,14 +146,7 @@ class QaseConverter:
     ) -> ResultCreate:
         """Prepare result report for failed test."""
         comment = constants.TEST_FAILED.format(when=report.when)
-        debug_information = (
-            debug_info.DebugInfo(
-                item=item,
-                webdriver=item._webdriver,
-            )
-            if hasattr(item, "_webdriver")
-            else None
-        )
+        debug_information = self._config.hook.pytest_get_debug_info(item=item)
         if debug_information and self._file_storage:
             folder = constants.REPORT_FOLDER_TEMPLATE.format(
                 env=self._env,

--- a/pytest_qaseio/debug_info.py
+++ b/pytest_qaseio/debug_info.py
@@ -2,21 +2,32 @@ import base64
 import logging
 import typing
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 import arrow
-from _pytest.python import Function
-from selenium.webdriver.remote.webdriver import WebDriver
 
 from . import constants, storage
 
+if TYPE_CHECKING:
+    from selenium.webdriver.remote.webdriver import WebDriver
 
-class DebugInfo:
-    """Representation of debug information."""
 
-    def __init__(self, item: Function, webdriver: WebDriver):
-        """Set error log and extract data from extra."""
-        self.webdriver: WebDriver = webdriver
-        self.test_name = item.name
+class DebugInfo(typing.Protocol):
+    """Protocol for representing required debug info objects interfaces."""
+
+    def generate_debug_comment(
+        self,
+        file_storage: storage.FileStorage,
+        folder: str,
+    ) -> str: ...
+
+
+class SeleniumDebugInfo:
+    """Representation of selenium debug information."""
+
+    def __init__(self, webdriver: "WebDriver"):
+        """Set error log and extract data from webdriver."""
+        self.webdriver = webdriver
         self.logger = logging.getLogger(__name__)
         self.screenshot = self._extract_screenshot()
         self.html = self._extract_html()

--- a/pytest_qaseio/hooks.py
+++ b/pytest_qaseio/hooks.py
@@ -1,5 +1,7 @@
 import pytest
 
+from pytest_qaseio.debug_info import DebugInfo
+
 from . import storage
 
 
@@ -18,3 +20,8 @@ def pytest_qase_file_storages() -> dict[str, storage.FileStorage]:  # type: igno
 @pytest.hookspec(firstresult=True)
 def pytest_qase_browser_name(config: pytest.Config) -> str:  # type: ignore
     """Return name of browser to use in test run name and attachments path."""
+
+
+@pytest.hookspec(firstresult=True)
+def pytest_get_debug_info(item: pytest.Function) -> DebugInfo | None:
+    """Return object with test debug information."""

--- a/pytest_qaseio/storage.py
+++ b/pytest_qaseio/storage.py
@@ -7,7 +7,7 @@ from qase.api_client_v1.api_client import ApiClient
 
 
 class FileStorage(Protocol):
-    """Base class for file uploader."""
+    """Protocol for representing required file uploader interfaces."""
 
     def save_file_obj(self, content: bytes, filename: str) -> str:
         """Upload file to storage and return URL."""


### PR DESCRIPTION
Add `pytest_get_debug_info` pytest hook.

This allows customizing `DebugInfo` for failed tests in various testing frameworks. Previously it was based on selenium webdriver which isn't compatible with other frameworks (e.g. `Playwright`).

By default, `pytest_get_debug_info` will return `SeleniumDebugInfo`, as before.