### PR TITLE
Update project urls

### DIFF
--- a/.vscode/project-related-words.txt
+++ b/.vscode/project-related-words.txt
@@ -31,3 +31,4 @@ firstresult
 ipdb
 geckodriver
 xfailed
+releasenotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,6 @@ authors = [
 
 readme = "README.md"
 
-homepage = "https://pypi.org/project/pytest-qaseio/"
-repository = "https://github.com/saritasa-nest/pytest-qaseio"
-
 keywords = [
   "pytest",
   "qase",
@@ -40,6 +37,12 @@ dependencies = [
     "pytest (>=7.2.2,<9.0.0)",
     "qase-api-client (>=1.1.1,<2.0.0)",
 ]
+
+[project.urls]
+homepage = "https://pypi.org/project/pytest-qaseio/"
+repository = "https://github.com/saritasa-nest/pytest-qaseio"
+changelog = "https://github.com/saritasa-nest/pytest-qaseio/blob/main/CHANGELOG.md"
+releasenotes = "https://github.com/saritasa-nest/pytest-qaseio/releases"
 
 [tool.poetry.plugins."pytest11"]
 pytest_qaseio = "pytest_qaseio.plugin"


### PR DESCRIPTION
Due to incorrect links data, renovate bot cannot attach link of updated package.
<img width="608" height="83" alt="image" src="https://github.com/user-attachments/assets/509c6327-4559-4c65-ad26-cab3e03f2f57" />
