### PR TITLE
Report all statuses to qaseio

### DIFF
--- a/.vscode/project-related-words.txt
+++ b/.vscode/project-related-words.txt
@@ -1,6 +1,8 @@
 addhooks
 addinivalue
 addoption
+argnames
+argvalues
 autotests
 autouse
 Azanov
@@ -18,6 +20,7 @@ makereport
 modifyitems
 nodeid
 Oboleninov
+parametrizing
 pluginmanager
 qase
 qase's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ We follow [Semantic Versions](https://semver.org/).
 ## Unreleased
 
 - Set up docs generation with `mkdocs`
+- Update logic for reporting statuses to qaseio [#151](https://github.com/saritasa-nest/pytest-qaseio/pull/151)
+
+  Now all statuses will be reported to qaseio, regardless of their order.
+  This changes expectation for tests implementation - now plugin supports
+  <https://github.com/pytest-dev/pytest-rerunfailures>,
+  but doesn't work well with parametrized tests.
 
 ## 2.7.3 (10.12.25)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,8 @@ inv pre-commit.run-hooks
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1. The pull request should include tests.
-2. If the pull request adds functionality, the docs should be updated.
+1. If the pull request adds functionality, the docs should be updated.
    Put your new functionality into a function with a docstring, and add
    the feature to the list in README.md.
-3. The pull request should work for each supported Python version.
+2. The pull request should work for each supported Python version.
    Check github actions status, verify that all checks have been passed.

--- a/README.md
+++ b/README.md
@@ -64,6 +64,31 @@ def test_demo():
     """Check qaseio plugin works as expected."""
 ```
 
+Each pytest item should be associated with a single Qase case.
+Avoid parametrizing a test/fixture when its parameters requires multiple
+runs of the same test with different params, but all of them required to check
+single case.
+In the meantime, it's OK to use parametrization for testing multiple cases
+using single pytest item, example:
+
+```python
+@pytest.mark.parametrize(
+    argnames="feature_enabled",
+    argvalues=[
+        pytest.param(
+            False,
+            marks=pytest.mark.qase("https://app.qase.io/case/DEMO-1"),
+        ),
+        pytest.param(
+            True,
+            marks=pytest.mark.qase("https://app.qase.io/case/DEMO-1"),
+        ),
+    ],
+)
+def test_feature_displaying(feature_enabled: bool):
+    pass
+```
+
 Since this package is mostly used for selenium tests, it expects to get browser
 name to use in Qase.io test run name and in attachments path. By default you can
 provide it using `--webdriver` flag. But you can also override

--- a/pytest_qaseio/plugin.py
+++ b/pytest_qaseio/plugin.py
@@ -248,12 +248,11 @@ class QasePlugin:
         )
         if not should_report:
             return
-        case_id = self._tests[item.nodeid]
 
-        # No need to report same passed status,
-        # while skipped and failed should be always reported
-        if not case_id or (case_id in self._qase_results and report.passed):
+        case_id = self._tests[item.nodeid]
+        if not case_id:
             return
+
         if not self._current_run:
             raise plugin_exceptions.RunNotConfigured()
         try:


### PR DESCRIPTION
Previously there was a logic like
> If test passed multiple times - store only first passed status
> But if test failed/skipped - store all such results

It was designed to be used with parametrized fixtures, when multiple pytest items are related to single case from Qaseio.

But this approach doesn’t work with https://github.com/pytest-dev/pytest-rerunfailures
When test passed after re-run, by previous logic it was still marked as failed.

Updated logic forces developers to use single test for single case and avoid parametrization for single case.

How it looks in qase:
<img height="451" alt="image" src="https://github.com/user-attachments/assets/3e419a45-0384-4bd1-9925-f04fc037a8c2" />

